### PR TITLE
Calculate last "zero day" and show as metric on streamlit dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -144,8 +144,18 @@ def filter_df_by_lga(input_df: pd.DataFrame) -> pd.DataFrame:
     return res_df[res_df.lga == lga_name]
 
 
-def find_zero_days(input_df: pd.DataFrame) -> pd.DataFrame:
-    return
+def find_last_zero_day(input_df: pd.DataFrame, start_date, end_date):
+    d_range = pd.date_range(start_date, end_date, freq="d")
+    dates_df = pd.DataFrame(d_range)
+    dates_df.columns = ["date"]
+
+    input_df.date = pd.to_datetime(input_df.date)
+    zero_days_imputed_df = dates_df.merge(input_df, how="left").fillna(0)
+    last_zero_day = (
+        zero_days_imputed_df.date[zero_days_imputed_df.cases_count == 0]
+    ).max()
+    last_zero_day_formatted = datetime.datetime.strftime(last_zero_day, "%d %b %Y")
+    return last_zero_day_formatted
 
 
 def main():
@@ -154,6 +164,7 @@ def main():
     )
 
     covid_df = load_and_clean_csv()
+    dataset_start_date = get_start_date()
     dataset_last_updated_date = get_last_updated_date()
     dataset_last_updated_date_formatted = dataset_last_updated_date.strftime("%d %b %Y")
 
@@ -164,7 +175,7 @@ def main():
     covid_df = filter_df_by_lga(covid_df)
 
     # metrics
-    total_cases_metric, total_daily_cases_metric, days_since_zero_day = st.columns(3)
+    total_cases_metric, total_daily_cases_metric, last_zero_day_metric = st.columns(3)
     total_cases = int(covid_df.cases_count.sum())
     total_cases_metric.metric(label="Total Cases", value=f"{total_cases:,}")
 
@@ -187,6 +198,14 @@ def main():
         delta_color="inverse",
         help='Due to time-lag in reporting, cases are reported up to and including the day before the "Last updated" date',
     )
+
+    last_zero_day = find_last_zero_day(
+        covid_df,
+        start_date=dataset_start_date,
+        end_date=day_before_date,
+    )
+
+    last_zero_day_metric.metric(label="Last Zero Day", value=last_zero_day)
 
     # visualisations
     st.markdown("**Daily Cases**")

--- a/dashboard.py
+++ b/dashboard.py
@@ -31,6 +31,14 @@ def load_and_clean_csv() -> pd.DataFrame:
 
 
 @st.cache_data
+def get_start_date() -> datetime.date:
+    covid_df = load_and_clean_csv()
+    first_case_date = min(covid_df.date)
+    first_case_date_datetime = datetime.datetime.strptime(first_case_date, "%Y-%m-%d")
+    return first_case_date_datetime.date()
+
+
+@st.cache_data
 def get_last_updated_date() -> datetime.date:
     DRIVER = setup_chromedriver()
     data_nsw_url = "https://data.nsw.gov.au/search/dataset/ds-nsw-ckan-aefcde60-3b0c-4bc0-9af1-6fe652944ec2/details?q="
@@ -134,6 +142,10 @@ def filter_df_by_lga(input_df: pd.DataFrame) -> pd.DataFrame:
     if lga_name == "All":
         return res_df
     return res_df[res_df.lga == lga_name]
+
+
+def find_zero_days(input_df: pd.DataFrame) -> pd.DataFrame:
+    return
 
 
 def main():

--- a/dashboard.py
+++ b/dashboard.py
@@ -31,14 +31,6 @@ def load_and_clean_csv() -> pd.DataFrame:
 
 
 @st.cache_data
-def get_start_date() -> datetime.date:
-    covid_df = load_and_clean_csv()
-    first_case_date = min(covid_df.date)
-    first_case_date_datetime = datetime.datetime.strptime(first_case_date, "%Y-%m-%d")
-    return first_case_date_datetime.date()
-
-
-@st.cache_data
 def get_last_updated_date() -> datetime.date:
     DRIVER = setup_chromedriver()
     data_nsw_url = "https://data.nsw.gov.au/search/dataset/ds-nsw-ckan-aefcde60-3b0c-4bc0-9af1-6fe652944ec2/details?q="
@@ -150,7 +142,6 @@ def main():
     )
 
     covid_df = load_and_clean_csv()
-    # dataset_start_date = get_start_date()
     dataset_last_updated_date = get_last_updated_date()
     dataset_last_updated_date_formatted = dataset_last_updated_date.strftime("%d %b %Y")
 
@@ -159,13 +150,6 @@ def main():
 
     st.sidebar.header("Filters")
     covid_df = filter_df_by_lga(covid_df)
-
-    # date_range = st.sidebar.date_input(
-    #     "Date Range",
-    #     min_value=dataset_start_date,
-    #     max_value=dataset_last_updated_date,
-    #     value=[dataset_start_date, dataset_last_updated_date],
-    # )
 
     # metrics
     total_cases_metric, total_daily_cases_metric, days_since_zero_day = st.columns(3)
@@ -191,8 +175,6 @@ def main():
         delta_color="inverse",
         help='Due to time-lag in reporting, cases are reported up to and including the day before the "Last updated" date',
     )
-
-    # days_since_zero_day.metric(label='Days Since Last "Zero" Day', value=)
 
     # visualisations
     st.markdown("**Daily Cases**")


### PR DESCRIPTION
The last date that there were no COVID cases reported is calculated using the `find_last_zero_day()` function. 

See below for preview of metric, which is also filterable by LGA in sidebar:
![image](https://user-images.githubusercontent.com/83106787/230349657-613edfb1-db88-40d6-af56-777cbf7cb729.png)
